### PR TITLE
Fixes for C++17 

### DIFF
--- a/string.hpp
+++ b/string.hpp
@@ -27,7 +27,10 @@ namespace cpp {
  */
 template <typename CharT, typename Traits, typename Allocator>
 std::basic_string<CharT, Traits, Allocator>& ltrim(std::basic_string<CharT, Traits, Allocator>& s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+									[](unsigned char c) {
+										return !std::isspace(c);
+									}));
     return s;
 }
 
@@ -40,7 +43,10 @@ std::basic_string<CharT, Traits, Allocator>& ltrim(std::basic_string<CharT, Trai
  */
 template <typename CharT, typename Traits, typename Allocator>
 std::basic_string<CharT, Traits, Allocator>& rtrim(std::basic_string<CharT, Traits, Allocator>& s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+						 [](unsigned char c) {
+							 return !std::isspace(c);
+						 }).base(), s.end());
     return s;
 }
 

--- a/string.hpp
+++ b/string.hpp
@@ -28,7 +28,7 @@ namespace cpp {
 template <typename CharT, typename Traits, typename Allocator>
 std::basic_string<CharT, Traits, Allocator>& ltrim(std::basic_string<CharT, Traits, Allocator>& s) {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-									[](unsigned char c) {
+									[](CharT c) {
 										return !std::isspace(c);
 									}));
     return s;
@@ -44,7 +44,7 @@ std::basic_string<CharT, Traits, Allocator>& ltrim(std::basic_string<CharT, Trai
 template <typename CharT, typename Traits, typename Allocator>
 std::basic_string<CharT, Traits, Allocator>& rtrim(std::basic_string<CharT, Traits, Allocator>& s) {
     s.erase(std::find_if(s.rbegin(), s.rend(),
-						 [](unsigned char c) {
+						 [](CharT c) {
 							 return !std::isspace(c);
 						 }).base(), s.end());
     return s;


### PR DESCRIPTION
std::ptr_fun was fully removed in 17, clang won't allow it.  Use of lambdas is preferred. Should be compatible with C++11 but did not test.